### PR TITLE
Integrate the duplicate endpoint to our frontend

### DIFF
--- a/contentcuration/contentcuration/dev_settings.py
+++ b/contentcuration/contentcuration/dev_settings.py
@@ -1,4 +1,8 @@
 from .settings import *
 
+import logging
+
 DEBUG = True
 ALLOWED_HOSTS = []
+
+logging.basicConfig(level='DEBUG')

--- a/contentcuration/contentcuration/static/js/edit_channel/models.js
+++ b/contentcuration/contentcuration/static/js/edit_channel/models.js
@@ -49,15 +49,24 @@ var NodeModel = BaseModel.extend({
 
 	/*Used when copying items to clipboard*/
     duplicate: function(target_parent){
-    	var start = new Date().getTime();
-    	var data = this.pick('title', 'created', 'modified', 'description', 'sort_order', 'license_owner', 'license','kind');
-		var node_data = new NodeModel();
-		var nodeChildrenCollection = new NodeCollection();
-		var self = this;
-		node_data.set(data);
-		node_data.move(target_parent, true, target_parent.get("children").length);
-		self.copy_children(node_data, self.get("children"));
-		return node_data;
+        var node_id = this.get("id");
+        var sort_order = target_parent.get("children").length;
+        var parent_id = target_parent.get("id");
+        var data = {node_id: node_id,
+                    sort_order: sort_order,
+                    target_parent: parent_id};
+        var new_node_data;
+        $.post({
+            url: window.Urls.duplicate_node(),
+            data: data,
+            async: false,
+            success: function(data) {
+                var data = JSON.parse(data);
+                new_node_data = new NodeModel(data);
+            }
+        });
+        new_node_data.fetch({cache: false});
+        return new_node_data;
 	},
 
 	move:function(target_parent, allow_duplicate, sort_order){

--- a/contentcuration/contentcuration/urls.py
+++ b/contentcuration/contentcuration/urls.py
@@ -90,7 +90,7 @@ urlpatterns = [
     url(r'^admin/', include(admin.site.urls)),
     url(r'^api/', include(router.urls)),
     url(r'^api/', include(bulkrouter.urls)),
-    url(r'^api/copy_node/$', views.copy_node, name='copy_node'),
+    url(r'^api/duplicate_node/$', views.duplicate_node, name='duplicate_node'),
     url(r'^api-auth/', include('rest_framework.urls', namespace='rest_framework')),
     url(r'exercises/$', views.exercise_list, name='exercise_list'),
     url(r'exercises/(?P<exercise_id>\w+)', views.exercise, name='exercise'),

--- a/contentcuration/contentcuration/views.py
+++ b/contentcuration/contentcuration/views.py
@@ -1,7 +1,7 @@
 import copy
 import json
 from rest_framework import status
-from django.http import Http404, HttpResponse
+from django.http import Http404, HttpResponse, HttpResponseBadRequest
 from django.views.decorators.csrf import csrf_exempt
 from django.shortcuts import render, get_object_or_404, redirect
 from django.contrib.auth.decorators import login_required
@@ -100,15 +100,14 @@ def file_upload(request):
 @csrf_exempt
 def copy_node(request):
     if request.method != 'POST':
-        pass
+        raise HttpResponseBadRequest("Only POST requests are allowed on this endpoint.")
     else:
         data = json.loads(request.body)
 
         try:
             node_id = data["node_id"]
         except KeyError:
-            # return error that no node_id in json was found
-            raise ObjectDoesNotExist("Node id %s not given.".format(node_id))
+            raise ObjectDoesNotExist("Node id %s not in POST data.".format(node_id))
 
         new_node = _copy_node(node_id, root=True)
 

--- a/contentcuration/contentcuration/views.py
+++ b/contentcuration/contentcuration/views.py
@@ -110,21 +110,21 @@ def copy_node(request):
             # return error that no node_id in json was found
             raise ObjectDoesNotExist("Node id %s not given.".format(node_id))
 
-        new_node = _copy_node(node_id)
+        new_node = _copy_node(node_id, root=True)
 
         return HttpResponse(json.dumps({"node_id": new_node.id}))
 
 
-def _copy_node(node):
+def _copy_node(node, root=False):
     if isinstance(node, int):
         node = Node.objects.get(pk=node)
 
     node = copy.copy(node)
     node.id = node.pk = None
-    node.parent = None
+    node.parent = None if root else node.parent
     node.published = False
 
-    node.children = [_copy_node(c) for c in node.children.all()]
+    node.children = [_copy_node(c, root=False) for c in node.children.all()]
     node.save()
 
     return node

--- a/contentcuration/contentcuration/views.py
+++ b/contentcuration/contentcuration/views.py
@@ -117,7 +117,8 @@ def duplicate_node(request):
         logging.info("Copying node id %s", node_id)
         new_node = _duplicate_node(node_id, parent=target_parent)
 
-        return HttpResponse(json.dumps({"node_id": new_node.id}))
+        serialized_node = NodeSerializer(new_node)
+        return HttpResponse(JSONRenderer().render(serialized_node.data))
 
 
 def _duplicate_node(node, parent=None):


### PR DESCRIPTION
![screen shot 2016-05-05 at 17 30 14](https://cloud.githubusercontent.com/assets/191955/15040416/344e99a2-12e7-11e6-8692-c3ce8def1dda.png)

Changes:
- Make the endpoint use standard POST data parsing.
- Make the endpoint return more data to the client (aka what Backbone needs to fully display the new node)
- Make the duplicate function use the new endpoint.
